### PR TITLE
Make 'ensure' subcommand explicit and necessary

### DIFF
--- a/openstack-flavor-manager/main.py
+++ b/openstack-flavor-manager/main.py
@@ -12,6 +12,10 @@ def ensure(url: str, cloudbackend: str = typer.Option("openstack"), recommended:
     object = Ensure(cloud=cloud, url=url, recommended=recommended)
     object.ensure()
 
+# Add empty callback to enable "ensure" as a single command in typer
+@app.callback()
+def callback():
+    pass
 
 def main():
     app()


### PR DESCRIPTION
The typer Python module automatically skips commands, if the app only has one single command. By adding an empty callback, the 'ensure' command is made explicitly available and necessary.

Fixes #14