### PR TITLE
Refactored Manifest parsing by using get_spec_or_default at cloud.py

### DIFF
--- a/openstack-flavor-manager/cloud.py
+++ b/openstack-flavor-manager/cloud.py
@@ -6,6 +6,19 @@ import openstack
 import os
 
 
+def get_spec_or_default(key_string, flavor_spec, defaults):
+    if key_string in flavor_spec:
+        return flavor_spec[key_string]
+    elif key_string in defaults:
+        return defaults[key_string]
+    else:
+        raise UnknownSpecKeyException
+
+
+class UnknownSpecKeyException(BaseException):
+    pass
+
+
 class Cloud:
     openstack = {
         "name": "name",
@@ -29,17 +42,17 @@ class Cloud:
             flavor_list = self.conn.search_flavors()
             return flavor_list
 
-    def set_flavor(self, flavor_spec: dict) -> int:
+    def set_flavor(self, flavor_spec: dict, defaults: dict) -> int:
         if self.backend == "openstack":
             flavor_id = self.conn.create_flavor(
-                name=flavor_spec['name'],
-                ram=flavor_spec['ram'],
-                vcpus=flavor_spec['cpus'],
-                disk=flavor_spec['disk'],
+                name=get_spec_or_default(key_string='name', flavor_spec=flavor_spec, defaults=defaults),
+                ram=get_spec_or_default(key_string='ram', flavor_spec=flavor_spec, defaults=defaults),
+                vcpus=get_spec_or_default(key_string='cpus', flavor_spec=flavor_spec, defaults=defaults),
+                disk=get_spec_or_default(key_string='disk', flavor_spec=flavor_spec, defaults=defaults),
                 ephemeral=0,
                 swap=0,
                 rxtx_factor=1.0,
-                is_public=flavor_spec['public']
+                is_public=get_spec_or_default(key_string='public', flavor_spec=flavor_spec, defaults=defaults)
             )
             # description
             # properties

--- a/openstack-flavor-manager/ensure.py
+++ b/openstack-flavor-manager/ensure.py
@@ -1,22 +1,25 @@
 import logging
-
 from cloud import Cloud
-from reference import get_url
 
 
 logging.basicConfig(format='%(levelname)s: %(message)s')
 
 
 class Ensure:
-    def __init__(self, cloud: Cloud, url: str, recommended: bool = False):
-        self.required_flavors = get_url(url, 'mandatory')
+    def __init__(self, cloud: Cloud, url: str, recommended: bool = False, definitions: dict = None) -> None:
+        self.required_flavors = definitions['mandatory']
         self.cloud = cloud
         if recommended:
-            self.required_flavors = self.required_flavors + get_url(url, 'recommended')
+            self.required_flavors = self.required_flavors + definitions['recommended']
+
+        self.defaults_dict = {}
+        for item in definitions['reference']:
+            if 'default' in item:
+                self.defaults_dict[item['field']] = item['default']
 
     def ensure(self) -> None:
         for required_flavor in self.required_flavors:
-            flavor_id = self.cloud.set_flavor(flavor_spec=required_flavor)
+            flavor_id = self.cloud.set_flavor(flavor_spec=required_flavor, defaults=self.defaults_dict)
             if flavor_id:
                 logging.info(f"Flavor created: {required_flavor['name']}")
             else:

--- a/openstack-flavor-manager/main.py
+++ b/openstack-flavor-manager/main.py
@@ -1,5 +1,5 @@
 import typer
-
+from reference import get_url
 from cloud import Cloud
 from ensure import Ensure
 
@@ -7,10 +7,11 @@ app = typer.Typer(help="Client to manage OpenStack flavors")
 
 
 @app.command("ensure")
-def ensure(url: str, cloudbackend: str = typer.Option("openstack"), recommended: bool = False) -> None:
-    cloud = Cloud(backend=cloudbackend)
-    object = Ensure(cloud=cloud, url=url, recommended=recommended)
-    object.ensure()
+def ensure(url: str, cloud_backend: str = typer.Option("openstack"), recommended: bool = False) -> None:
+    flavour_definitions = get_url(url)  # Get the default values from the reference
+    cloud = Cloud(backend=cloud_backend)
+    ensure_object = Ensure(cloud=cloud, url=url, recommended=recommended, definitions=flavour_definitions)
+    ensure_object.ensure()
 
 
 def main():
@@ -19,3 +20,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/openstack-flavor-manager/reference.py
+++ b/openstack-flavor-manager/reference.py
@@ -2,7 +2,7 @@ import requests
 import yaml
 
 
-def get_url(url: str, key: str) -> list:
+def get_url(url: str) -> dict:
     if url == "scs":
         url = "https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Tests/iaas/SCS-Spec.MandatoryFlavors.verbose.yaml"
     if url == "osism":
@@ -11,17 +11,6 @@ def get_url(url: str, key: str) -> list:
     result = requests.get(url)
     try:
         result = yaml.safe_load(result.content)
+        return result
     except yaml.YAMLError as exc:
         print(exc)
-
-    # depending on the source of origin, the data might need to be cleaned up
-    cleaned_list = []
-    for item in result[key]:
-        # scs exports a field description which has to be ignored
-        if "description" in item:
-            item.pop("description")
-        cleaned_list.append(item)
-
-    result[key] = cleaned_list
-
-    return result[key]


### PR DESCRIPTION
The flavor spec defaults were not handled correctly. This commit, will fix this behavior.
Besides, we should check the defaults yaml files obtained by the script at:

- https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Tests/iaas/SCS-Spec.MandatoryFlavors.verbose.yaml
- https://raw.githubusercontent.com/osism/openstack-flavor-manager/main/flavors.yaml

Sometimes a boolean value is getting indicated as true (bool) and at a different position as 'true' (string)

We should definitely make sure that this is getting unified, also from a coding perspective, its kinda ugly to parse manifest data like this.


fixes #15