### PR TITLE
Prevent script errors on existing flavours - Fix 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/openstack_flavor_manager/ensure.py
+++ b/openstack_flavor_manager/ensure.py
@@ -16,8 +16,10 @@ class Ensure:
 
     def ensure(self) -> None:
         for required_flavor in self.required_flavors:
-            flavor_id = self.cloud.set_flavor(flavor_spec=required_flavor, defaults=self.defaults_dict)
-            if flavor_id:
-                logging.info(f"Flavor created: {required_flavor['name']}")
-            else:
+            try:
+                flavor = self.cloud.set_flavor(flavor_spec=required_flavor, defaults=self.defaults_dict)
+                if flavor:
+                    logging.info(f"Flavor created: {required_flavor['name']}")
+            except Exception as e:
                 logging.error(f"Flavor could not be created: {required_flavor['name']}")
+                logging.error(e)

--- a/openstack_flavor_manager/reference.py
+++ b/openstack_flavor_manager/reference.py
@@ -12,8 +12,6 @@ def get_url(url: str) -> dict:
     logging.debug(f"Loading flavor definitions from {url}")
 
     result = requests.get(url)
+    result.raise_for_status()
 
-    try:
-        return yaml.safe_load(result.content)
-    except yaml.YAMLError as exc:
-        logging.error(exc)
+    return yaml.safe_load(result.content)


### PR DESCRIPTION
Store which flavours where already present in OpenStack
and prevent duplicated API calls for the flavours create call
against OpenStack API.

fixes #17