### PR TITLE
Add cli-option to set log level to DEBUG

### DIFF
--- a/openstack_flavor_manager/main.py
+++ b/openstack_flavor_manager/main.py
@@ -15,14 +15,19 @@ def ensure(url: str, cloud_backend: str = typer.Option("openstack"), recommended
     ensure_object.ensure()
 
 
-# Add empty callback to enable "ensure" as a single command in typer
+# This is needed for:
+# 1) Global app option handling
+# 2) Prevent that the single "ensure" command is automatically ommited
 @app.callback()
-def callback():
-    pass
+def callback(debug_logging: bool = typer.Option(False, "--debug", help="Enable debug logging")):
+    logging.basicConfig(
+        level=logging.INFO if not debug_logging else logging.DEBUG,
+        format="%(asctime)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
 
 
 def main():
-    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     app()
 
 


### PR DESCRIPTION
Apply logging format of the osism-image-manager and add the option to set the application logging to DEBUG with the --debug flag

Also use the logging format of osism-image-manager.

Fixes #30