### PR TITLE
Make sure we interpret bool and bool announced as string the same way

### DIFF
--- a/openstack_flavor_manager/cloud.py
+++ b/openstack_flavor_manager/cloud.py
@@ -8,17 +8,29 @@ import openstack
 import os
 
 
-def get_spec_or_default(key_string: str, flavor_spec: dict, defaults: dict) -> object:
-    if key_string in flavor_spec:
-        return flavor_spec[key_string]
-    elif key_string in defaults:
-        return defaults[key_string]
+def str_to_bool(string_bool: str | bool) -> bool:
+    if isinstance(string_bool, bool):
+        return string_bool
+    s = str(string_bool).lower()
+    if s == 'true':
+        return True
+    elif s == 'false':
+        return False
     else:
-        raise UnknownSpecKeyException
+        raise ValueError(f"Unknown boolean value '{string_bool}'")
 
 
-class UnknownSpecKeyException(BaseException):
-    pass
+def get_spec_or_default(key_string: str, flavor_spec: dict, defaults: dict, is_bool: bool = False):
+    if key_string in flavor_spec:
+        value = flavor_spec[key_string]
+    elif key_string in defaults:
+        value = defaults[key_string]
+    else:
+        raise ValueError(f"Unknown key_string '{key_string}'")
+
+    if is_bool:
+        return str_to_bool(value)
+    return value
 
 
 class Cloud:
@@ -43,7 +55,7 @@ class Cloud:
             ephemeral=0,
             swap=0,
             rxtx_factor=1.0,
-            is_public=get_spec_or_default(key_string='public', flavor_spec=flavor_spec, defaults=defaults)
+            is_public=get_spec_or_default(key_string='public', flavor_spec=flavor_spec, defaults=defaults, is_bool=True)
         )
         self.conn.set_flavor_specs(
             flavor_id=flavor.id,

--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -288,6 +288,40 @@ class TestCloud(unittest.TestCase):
 
     def test_spec_or_default_2(self):
         test_spec = {
+            "existing_key": "true",
+            "existing_key_2": True,
+            "existing_key_3": "false",
+            "existing_key_4": False,
+            "existing_key_5": "TrUe",
+            "existing_key_6": "notabool",
+        }
+        default_spec = {
+            "default_key": "true",
+            "default_key_2": False
+        }
+
+        # Check if is_bool flag is honored
+        self.assertEqual(cloud.get_spec_or_default("existing_key", test_spec, default_spec, is_bool=False), "true")
+
+        # Check if booleans are converted correctly
+        self.assertEqual(cloud.get_spec_or_default("existing_key", test_spec, default_spec, is_bool=True), True)
+        self.assertEqual(cloud.get_spec_or_default("existing_key_2", test_spec, default_spec, is_bool=True), True)
+        self.assertEqual(cloud.get_spec_or_default("existing_key_3", test_spec, default_spec, is_bool=True), False)
+        self.assertEqual(cloud.get_spec_or_default("existing_key_4", test_spec, default_spec, is_bool=True), False)
+        self.assertEqual(cloud.get_spec_or_default("existing_key_5", test_spec, default_spec, is_bool=True), True)
+
+        self.assertRaises(ValueError,
+                          cloud.get_spec_or_default,
+                          "existing_key_6",
+                          test_spec,
+                          default_spec,
+                          is_bool=True)
+
+        self.assertEqual(cloud.get_spec_or_default("default_key", test_spec, default_spec, is_bool=True), True)
+        self.assertEqual(cloud.get_spec_or_default("default_key_2", test_spec, default_spec, is_bool=True), False)
+
+    def test_spec_or_default_3(self):
+        test_spec = {
             "existing_key": "value1",
             "existing_key_2": "value2"
         }
@@ -297,8 +331,7 @@ class TestCloud(unittest.TestCase):
         }
 
         # Check if Exception is raised
-        self.assertRaises(cloud.UnknownSpecKeyException, cloud.get_spec_or_default, "unknown_key", test_spec,
-                          default_spec)
+        self.assertRaises(ValueError, cloud.get_spec_or_default, "unknown_key", test_spec, default_spec)
 
     @mock.patch("openstack.openstack.connect")
     def test_init_0(self, mock_connect):


### PR DESCRIPTION
Some yml files for creating the flavor are announcing some field values like 'true' and not true. this change makes sure we are correctly interpreting them as bool's and not as strings. So practically both are now valid, either a bool or a string like 'true' will now work fine.

fixes #42
Signed-off-by: Robin van der Linden <linden@b1-systems.de>