### PR TITLE
Add pyproject.toml to prepare for packaged releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openstack-flavor-manager"
+description = "OpenStack flavor manager"
+authors = [
+  { name = "OSISM community", email = "info@osism.tech" },
+]
+license = { file = "LICENSE" }
+readme = "README.md"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
+]
+requires-python = ">=3.8"
+dynamic = ["dependencies", "version"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["openstack_flavor_manager"]
+
+[tool.setuptools-git-versioning]
+enabled = true
+dev_template = "{tag}"
+dirty_template = "{tag}"
+
+[project.scripts]
+openstack-flavor-manager = "openstack_flavor_manager.main:main"
+
+[project.urls]
+"Homepage" = "https://github.com/osism/openstack-flavor-manager"
+"Bug Tracker" = "https://github.com/osism/openstack-flavor-manager/issues"


### PR DESCRIPTION
Adapt the pyproject.toml used in the image-manager for use with the flavor-manager.

In later steps the publish pipeline may now use
setuptools>=61 to create the package.

Fixes #53