### PR TITLE
Provide compatibility with Python 3 versions older than 3.10

### DIFF
--- a/openstack_flavor_manager/main.py
+++ b/openstack_flavor_manager/main.py
@@ -6,6 +6,7 @@ import openstack
 import requests
 import sys
 import typer
+import typing
 import yaml
 
 
@@ -37,7 +38,9 @@ class Cloud:
         for flavor in flavors:
             self.existing_flavors[flavor.name] = flavor
 
-    def set_flavor(self, flavor_spec: dict, defaults: dict) -> Flavor | None:
+    def set_flavor(
+        self, flavor_spec: dict, defaults: dict
+    ) -> typing.Union[Flavor, None]:
         flavor_name = get_spec_or_default(
             key_string="name", flavor_spec=flavor_spec, defaults=defaults
         )


### PR DESCRIPTION
The `X | Y` notation[^1] for typing in Python was introduced in Python 3.10 and makes `openstack-flavor-manager` fail on older Python versions such as 3.9:

```
$ openstack-flavor-manager --help
Traceback (most recent call last):
  ...
    def set_flavor(self, flavor_spec: dict, defaults: dict) -> Flavor | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

This PR uses the backwards-compatible `typing.Union` instead which achieves the same and makes `openstack-flavor-manager` usable on older Python 3 releases as well.

[^1]: https://peps.python.org/pep-0604/