### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/extra-specs-support-020d7e544f1622cc.yaml
+++ b/releasenotes/notes/extra-specs-support-020d7e544f1622cc.yaml
@@ -1,3 +1,0 @@
----
-features:
-  - Add support for setting extra_specs, as well as setting the flavor id.

--- a/releasenotes/notes/hw_rng-allowed-c0e142170a2814d4.yaml
+++ b/releasenotes/notes/hw_rng-allowed-c0e142170a2814d4.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Add extra spec `hw_rng:allowed: True` to all flavors.
-    https://docs.scs.community/standards/scs-0101-v1-entropy

--- a/releasenotes/notes/integration-test-49cdd76748362e08.yaml
+++ b/releasenotes/notes/integration-test-49cdd76748362e08.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add integration test.

--- a/releasenotes/notes/local-storage-417e151981fc9383.yaml
+++ b/releasenotes/notes/local-storage-417e151981fc9383.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Add flavors with local storage and add `local_storage` extra spec
-    to all flavors.

--- a/releasenotes/notes/remove-local-storage-f8d88689f360e903.yaml
+++ b/releasenotes/notes/remove-local-storage-f8d88689f360e903.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Remove `local_storage` extra spec in favor of `scs:disk0-type` extra spec.

--- a/releasenotes/notes/scs-cpu-type-2131b95647e283df.yaml
+++ b/releasenotes/notes/scs-cpu-type-2131b95647e283df.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add `scs:cpu-type` to all flavors.

--- a/releasenotes/notes/scs-disk0-type-98dbb7f32825f577.yaml
+++ b/releasenotes/notes/scs-disk0-type-98dbb7f32825f577.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add `scs:disk0-type` to all flavors.

--- a/releasenotes/notes/update-extra-specs-844999f80699bad4.yaml
+++ b/releasenotes/notes/update-extra-specs-844999f80699bad4.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Update extra specs on existing flavors.

--- a/releasenotes/notes/update_unit_tests-19dcea90e5d37efb.yaml
+++ b/releasenotes/notes/update_unit_tests-19dcea90e5d37efb.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Update unit tests to comply with changes in 159588d8b2dae62f4ec474a9fb1371419ffb66a6


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.