### PR TITLE
Add note to flavors.yaml

### DIFF
--- a/flavors.yaml
+++ b/flavors.yaml
@@ -1,3 +1,7 @@
+# NOTE this file is not intended to make your environment fit for SCS.
+# For this purpose, use the file at
+# https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Tests/iaas/SCS-Spec.MandatoryFlavors.verbose.yaml
+# -- the openstack-image-manager will do that for you by default!
 ---
 reference:
   - field: name


### PR DESCRIPTION
We send people to this repo specifically with the aim to make their environment compliant with SCS.
The similarities of `flavors.yaml` with the SCS spec file are extremely high, yet it doesn't work for SCS.
Make a note so nobody uses the file for the wrong purpose.

Closing #154 