### PR TITLE
tests: mock network in flavor definitions test

### DIFF
--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -196,17 +196,34 @@ class TestGetFlavorDefinitions(unittest.TestCase):
         # Check if the function raises an invalid yaml exception
         self.assertRaises(ParserError, get_flavor_definitions, "scs", None)
 
-    def test_get_flavor_definitions_3(self):
-        # Here we _actually_ download the YML files uploaded to GitHub
-        # Therefore, this test requires an active internet connection
+    @patch("requests.Session.get")
+    def test_get_flavor_definitions_3(self, mock_get):
+        # Check that the 'scs' and 'osism' sources resolve to the correct
+        # GitHub URLs. The download is mocked so this test does not require
+        # network access (avoids adding load to raw.githubusercontent.com).
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = MOCK_YML
+
+        scs_url = (
+            "https://raw.githubusercontent.com/SovereignCloudStack/standards/"
+            "main/Tests/iaas/SCS-Spec.MandatoryFlavors.verbose.yaml"
+        )
+        osism_url = (
+            "https://raw.githubusercontent.com/osism/"
+            "openstack-flavor-manager/main/flavors.yaml"
+        )
 
         # Resolve 'scs' to correct url
         result = get_flavor_definitions("scs", None)
         self.assertIs(type(result), dict)
+        mock_get.assert_called_once_with(scs_url)
+
+        mock_get.reset_mock()
 
         # Resolve 'osism' to correct url
         result = get_flavor_definitions("osism", None)
         self.assertIs(type(result), dict)
+        mock_get.assert_called_once_with(osism_url)
 
     @patch("io.open")
     def test_get_flavor_definitions_4(self, mock_open):


### PR DESCRIPTION
## What

`test_get_flavor_definitions_3` previously performed **real HTTP downloads** of the SCS and OSISM flavor-definition YAML files from `raw.githubusercontent.com`, requiring live internet access on every test run. This change mocks `requests.Session.get` so the test no longer touches the network, matching the pattern already used by the other tests in `TestGetFlavorDefinitions`.

The test still verifies that the `scs` and `osism` sources resolve to the correct `raw.githubusercontent.com` URLs (now via `assert_called_once_with`) and that `get_flavor_definitions` returns a parsed `dict` — so coverage of the source-to-URL resolution is preserved and strengthened.

## Why

The unit-test job (`tox`, `envlist=test`) runs on every `check` (PR) and `periodic-daily` pipeline. Because this test hit `raw.githubusercontent.com` anonymously, it added GitHub request load on every run — fetching the same SCS spec URL that the integration-test job already downloads, plus the OSISM `flavors.yaml`.

This contributed to anonymous per-IP **HTTP 429 (Too Many Requests)** rate-limit failures against `raw.githubusercontent.com`. Concretely, the `periodic-daily` `openstack-flavor-manager-integration-test` job failed on 2026-07-09 with:

```
HTTPError: 429 Client Error: Too Many Requests for url:
https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Tests/iaas/SCS-Spec.MandatoryFlavors.verbose.yaml
```

Mocking this test removes the only network-touching unit test, eliminating redundant live fetches on every PR and daily run and removing a test that would itself flake under the same rate limit.

## Verification

- Full unit suite: **27/27 pass** in ~0.07s (down from seconds, since this test's two live round-trips are gone).
- Ran the test inside an isolated no-network namespace (`unshare -rn`) → **passes**, confirming zero network dependency.

## Notes

This is a targeted, low-risk fix for the unit-test job. It does **not** change the tool's runtime fetch behaviour (the integration job still fetches the SCS spec once). Further load/resilience improvements — e.g. retry-with-backoff, a token-authenticated fetch, or fetching the spec once in the playbook and passing it via `--url file://` — can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)